### PR TITLE
Add custom path converter with name `ulid`

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,21 @@ class OrganizationSerializer(serializers.ModelSerializer):
     owner = PersonPrimaryKeyRelatedField()
 ```
 
+You can use the type `ulid` as a path segment converter in your URLs, similar to the built-in `uuid` converter. It returns a `ULID` instance.
+
+```python
+import ulid
+from django.urls import path
+from django_ulid import path_converter 
+
+def person_view(request, id):
+    assert isinstance(id, ulid.ULID)
+
+urlpatterns = [
+    path('person/<ulid:id>/', person_view)
+]
+```
+
 ### Contributing
 
 If you would like to contribute, simply fork the repository, push your changes and send a pull request.

--- a/README.rst
+++ b/README.rst
@@ -92,6 +92,23 @@ to automatically serialize the instance through the foreign key.
    class OrganizationSerializer(serializers.ModelSerializer):
        owner = PersonPrimaryKeyRelatedField()
 
+You can use the type ``ulid`` as a path segment converter in your URLs,
+similar to the built-in ``uuid`` converter. It returns a ``ULID``
+instance.
+
+.. code:: python
+
+   import ulid
+   from django.urls import path
+   from django_ulid import path_converter 
+
+   def person_view(request, id):
+       assert isinstance(id, ulid.ULID)
+
+   urlpatterns = [
+       path('person/<ulid:id>/', person_view)
+   ]
+
 Contributing
 ~~~~~~~~~~~~
 

--- a/django_ulid/path_converter.py
+++ b/django_ulid/path_converter.py
@@ -1,0 +1,17 @@
+from typing import ClassVar
+
+import ulid
+from django.urls import register_converter
+
+
+class ULIDPathConverter:
+    regex: ClassVar[str] = r"[0-9A-TV-Za-tv-z]{26}"
+
+    def to_python(self, value: str) -> ulid.ULID:
+        return ulid.from_str(value)
+
+    def to_url(self, value: ulid.ULID) -> str:
+        return str(value)
+
+
+register_converter(ULIDPathConverter, "ulid")

--- a/tests/test_path_converter.py
+++ b/tests/test_path_converter.py
@@ -1,0 +1,41 @@
+from functools import partial
+from typing import Optional
+
+import pytest
+import ulid
+from django.urls import ResolverMatch, path
+
+from django_ulid import path_converter
+
+
+@pytest.fixture
+def pattern():
+    def view(request, id: ulid.ULID):
+        assert isinstance(id, ulid.ULID)
+        return id
+
+    return partial(path, "<ulid:id>/", view)
+
+
+def test_registered_converter(pattern):
+    """Attempt to create a URLPattern object with 'ulid' registered converter. It will
+    raise ImproperlyConfigured if it fails, otherwise it'll be created successfully."""
+    pattern()
+
+
+def test_resolving_pattern(pattern):
+    """Attempt to resolve the URLPattern object with a path. A path with a valid ULID
+    will return a ResolverMatch, with a ULID in the kwargs."""
+    ptrn = pattern()
+    test_ulid = "01EVZTQY9ZW1EG0QHBNRSQHN8S"
+    match: Optional[ResolverMatch] = ptrn.resolve(f"{test_ulid}/")
+    assert match
+    assert match.kwargs["id"] == ulid.from_str(test_ulid)
+
+
+def test_resolving_pattern_miss(pattern):
+    """Attempt to resolve the URLPattern object with a path. A path without a valid ULID
+    will return None."""
+    ptrn = pattern()
+    match = ptrn.resolve("not-a-ulid/")
+    assert match is None


### PR DESCRIPTION
Use the method for defining and registering a custom path converter documented at [0] to implement a path converter for a ULID object with the converter name `ulid`. Includes tests and README.

 [0]: https://docs.djangoproject.com/en/3.1/topics/http/urls/#registering-custom-path-converters